### PR TITLE
Fix: PHP8 Warning: Undefined array key "deleteConfirm"

### DIFF
--- a/src/Resources/contao/dca/tl_news_list.php
+++ b/src/Resources/contao/dca/tl_news_list.php
@@ -77,7 +77,7 @@ $GLOBALS['TL_DCA']['tl_news_list'] = [
                 'label' => &$GLOBALS['TL_LANG']['tl_news_list']['delete'],
                 'href' => 'act=delete',
                 'icon' => 'delete.svg',
-                'attributes' => 'onclick="if(!confirm(\''.$GLOBALS['TL_LANG']['MSC']['deleteConfirm'].'\'))return false;Backend.getScrollOffset()"',
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? 'confirm delete') . '\'))return false;Backend.getScrollOffset()"',
                 'button_callback' => ['HeimrichHannot\NewsBundle\Backend\NewsList', 'deleteList'],
             ],
             'show' => [

--- a/src/Resources/contao/dca/tl_news_list_archive.php
+++ b/src/Resources/contao/dca/tl_news_list_archive.php
@@ -59,7 +59,7 @@ $GLOBALS['TL_DCA']['tl_news_list_archive'] = [
                 'label'           => &$GLOBALS['TL_LANG']['tl_news_list_archive']['copy'],
                 'href'            => 'act=delete',
                 'icon'            => 'delete.gif',
-                'attributes'      => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+                'attributes'      => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? 'confirm delete') . '\'))return false;Backend.getScrollOffset()"',
                 'button_callback' => ['HeimrichHannot\NewsBundle\Backend\NewsListArchive', 'deleteArchive']
             ],
             'toggle'     => [


### PR DESCRIPTION
Return `"confirm delete"` for undefined array keys to prevent php8 warnings in dev mode.